### PR TITLE
Version 0.1.0

### DIFF
--- a/client/src/game/ActionSelector.jsx
+++ b/client/src/game/ActionSelector.jsx
@@ -104,7 +104,7 @@ function ActionSelector({uuid, enabled, update, updateActiveGame, setPositionOpt
                             />
                             <span>
                                 <label title={action.description} className={`${action.error ? "label-strikethrough" : ""}`}>{`${action.name}`}</label>
-                                { action.error ? <span>{action.error}</span> : <></> }
+                                { action.error ? <span> {action.error}</span> : <></> }
                             </span>
                         </div>
                     )}

--- a/client/src/game/ParameterSelector.jsx
+++ b/client/src/game/ParameterSelector.jsx
@@ -19,7 +19,7 @@ function ParameterSelector({parameter, callback, handlePositionSelection, select
         } else if (parameter.type === "PlayerRef") {
             return value?.name;
         } else if (parameter.type === "Specialty" || parameter.type === "Boon") {
-            return value?.variant;
+            return value?.name;
         } else {
             return `Unhandled type ${parameter.type}`;
         }
@@ -58,7 +58,7 @@ function ParameterSelector({parameter, callback, handlePositionSelection, select
         selector = "Unimplemented";
     } else {
         // ERROR
-        selector = "Unknown parameter bound type "+ parameter.bound;
+        selector = "Unknown parameter bound type " + parameter.bound;
     }
 
     return (

--- a/client/src/game/board/BoardCell.jsx
+++ b/client/src/game/board/BoardCell.jsx
@@ -1,6 +1,6 @@
 import "./BoardCell.css"
 import Popup from "reactjs-popup";
-import {codeObjectToString, ENGLISH_LOCALE, objectToArray, objectToLocalizedObject} from "../../util/locale.js";
+import {codeObjectToString, ENGLISH_LOCALE, objectToOrderedLocalizedObject} from "../../util/locale.js";
 import {useState} from "react";
 import Tank from "../../../assets/images/Tank.png"
 import Wall from "../../../assets/images/Wall.png"
@@ -70,7 +70,7 @@ function BoardCell({unit, floor, gameIsCurrent, selectMode, enabled, onClick, se
     let unitAttributes = [];
     let unitClassText = "Empty";
     if (unitClass) {
-        unitAttributes = objectToArray(objectToLocalizedObject(ENGLISH_LOCALE, unit));
+        unitAttributes = objectToOrderedLocalizedObject(ENGLISH_LOCALE, unit);
         if (unitClass === "PseudoTank") {
             unitClassText = "Fallen";
         } else if (unitClass === "Tank") {

--- a/client/src/util/locale.js
+++ b/client/src/util/locale.js
@@ -12,30 +12,48 @@ const ENGLISH_LOCALE = {
     SCRAP: "Scrap",
     SPEED: "Speed",
     RANGE: "Range",
-    POSITION: "Position",
     DURABILITY: "Durability",
     DAMAGE_MODIFIER: "Damage Modifier",
     DEFENSE_MODIFIER: "Defense Modifier",
     SPECIALTY: "Specialty",
+    BOON: "Upgrade",
     TEAM: "Team",
-    GLORY: "Glory",
     SPONSOR: "Sponsor",
 };
+
+function orderingByLocale(locale) {
+    return [
+        locale.TEAM,
+        locale.SPONSOR,
+        locale.DURABILITY,
+        locale.SCRAP,
+        locale.DAMAGE_MODIFIER,
+        locale.DEFENSE_MODIFIER,
+        locale.RANGE,
+        locale.SPEED,
+        locale.SPECIALTY,
+        locale.BOON,
+    ];
+}
 
 export function objectToLocalizedObject(locale, object) {
     const output = {};
     Object.keys(object)
         .filter((key) => Object.keys(locale).indexOf(codeToLocale(key)) > -1)
-        .map((key) => {
-            if (object[key]) {
+        .forEach((key) => {
+            if (object[key] !== undefined) {
                 output[locale[codeToLocale(key)]] = object[key];
             }
-        });
+        })
     return output;
 }
 
-export function objectToArray(object) {
-    return Object.keys(object).map((key) => ({key: key, value: object[key]}));
+export function objectToOrderedLocalizedObject(locale, object) {
+    const localizedObject = objectToLocalizedObject(locale, object);
+    const ordering = orderingByLocale(locale);
+    return ordering
+        .filter(((localeKey) => localizedObject[localeKey] !== undefined))
+        .map((localeKey) => ({key: localeKey, value: localizedObject[localeKey]}));
 }
 
 export function codeObjectToString(object) {
@@ -49,7 +67,7 @@ export function codeObjectToString(object) {
         } else if (type === "PlayerRef") {
             return object.name;
         } else if (type === "Specialty" || type === "Boon") {
-            return object.variant;
+            return object.name;
         }
     }
     return `Unhandled type ${type}`;

--- a/client/src/util/logbook.jsx
+++ b/client/src/util/logbook.jsx
@@ -24,13 +24,13 @@ export default function entryToText(entry) {
         } else if (entry.action === "Move") {
             return `${entry.subject.name} moves to ${positionToString(entry.target_position)}`;
         } else if (entry.action === "Specialize") {
-            return `${entry.subject.name} specializes in ${entry.target_specialty.variant}`;
+            return `${entry.subject.name} specializes in ${entry.target_specialty.name}`;
         } else if (entry.action === "Mine") {
             return `${entry.subject.name} mines and finds ${entry.scrap} scrap`;
         } else if (entry.action === "Repair") {
             return `${entry.subject.name} repairs unit on ${positionToString(entry.target_position)}`;
         } else if (entry.action === "Upgrade") {
-            return `${entry.subject.name} upgrades ${entry.target_boon.variant}`;
+            return `${entry.subject.name} upgrades ${entry.target_boon.name}`;
         } else if (entry.action === "Accept Sponsorship") {
             return `${entry.subject.name} accepts sponsorship from ${entry.target_player.name}`;
         } else if (entry.action === "Offer Sponsorship") {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>TankGameRedux</groupId>
     <artifactId>TankGameRedux</artifactId>
-    <version>0.0.1</version>
+    <version>0.1.0</version>
     <description>A simple tank game</description>
 
     <properties>

--- a/src/main/java/pro/trevor/tankgame/attribute/Attribute.java
+++ b/src/main/java/pro/trevor/tankgame/attribute/Attribute.java
@@ -11,6 +11,7 @@ import pro.trevor.tankgame.util.IRandom;
 
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 public class Attribute<E> {
@@ -66,6 +67,7 @@ public class Attribute<E> {
     public static final Attribute<Boolean> HAS_COMPELLED_FALLEN = new Attribute<>("HAS_COMPELLED_FALLEN", Boolean.class);
 
     // Log entry attributes
+    public static final Attribute<Boolean> SUCCESS = new Attribute<>("SUCCESS", Boolean.class);
     public static final Attribute<ListEntity> SUBENTRIES = new Attribute<>("SUBENTRIES", ListEntity.class); // ListEntity<LogEntry>
     public static final Attribute<String> ACTION = new Attribute<>("ACTION", String.class);
     public static final Attribute<PlayerRef> SUBJECT = new Attribute<>("SUBJECT", PlayerRef.class);
@@ -100,6 +102,17 @@ public class Attribute<E> {
 
     public Class<E> getAttributeClass() {
         return attributeClass;
+    }
+
+    public static Optional<Attribute<?>> fromString(String attributeString) {
+        return ATTRIBUTES.stream().filter((attr) -> attr.attributeName.equals(attributeString)).findAny();
+    }
+
+    public static <T> Optional<Attribute<T>> fromString(String attributeString, Class<T> type) {
+        return ATTRIBUTES.stream()
+                .filter((attr) -> attr.attributeName.equals(attributeString) && attr.attributeClass.isAssignableFrom(type))
+                .map((attr) -> (Attribute<T>) attr)
+                .findAny();
     }
 
     @Override

--- a/src/main/java/pro/trevor/tankgame/rule/Ruleset.java
+++ b/src/main/java/pro/trevor/tankgame/rule/Ruleset.java
@@ -13,7 +13,6 @@ public class Ruleset {
     private final ActionRuleset playerActionRuleset;
     private final ApplyRuleset tickRuleset;
     private final ApplyRuleset conditionalRuleset;
-    private final ApplyRuleset invariantRuleset;
 
     private final List<Damage> damageHandlers;
     private final List<Destroy> destroyHandlers;
@@ -22,7 +21,6 @@ public class Ruleset {
         this.playerActionRuleset = new ActionRuleset();
         this.tickRuleset = new ApplyRuleset();
         this.conditionalRuleset = new ApplyRuleset();
-        this.invariantRuleset = new ApplyRuleset();
 
         this.damageHandlers = new ArrayList<>();
         this.destroyHandlers = new ArrayList<>();
@@ -33,7 +31,6 @@ public class Ruleset {
         register.registerPlayerRules(this);
         register.registerTickRules(this);
         register.registerConditionalRules(this);
-        register.registerInvariantRules(this);
         register.registerDamageHandlers(this.damageHandlers);
         register.registerDestroyHandlers(this.destroyHandlers);
     }
@@ -48,10 +45,6 @@ public class Ruleset {
 
     public ApplyRuleset getConditionalRuleset() {
         return conditionalRuleset;
-    }
-
-    public ApplyRuleset getInvariantRuleset() {
-        return invariantRuleset;
     }
 
     public List<Damage> getDamageHandlers() {

--- a/src/main/java/pro/trevor/tankgame/rule/RulesetRegister.java
+++ b/src/main/java/pro/trevor/tankgame/rule/RulesetRegister.java
@@ -11,7 +11,6 @@ public interface RulesetRegister {
     void registerPlayerRules(Ruleset ruleset);
     void registerTickRules(Ruleset ruleset);
     void registerConditionalRules(Ruleset ruleset);
-    void registerInvariantRules(Ruleset ruleset);
     void registerDamageHandlers(List<Damage> damageHandlers);
     void registerDestroyHandlers(List<Destroy> destroysHandlers);
 

--- a/src/main/java/pro/trevor/tankgame/rule/RulesetRegistry.java
+++ b/src/main/java/pro/trevor/tankgame/rule/RulesetRegistry.java
@@ -1,12 +1,19 @@
 package pro.trevor.tankgame.rule;
 
 import pro.trevor.tankgame.Game;
+import pro.trevor.tankgame.rule.impl.ruleset.DefaultRulesetRegister;
+import pro.trevor.tankgame.rule.impl.ruleset.DefaultV2RulesetRegistry;
 
 import java.util.*;
 
 public class RulesetRegistry {
 
     public static final RulesetRegistry REGISTRY = new RulesetRegistry();
+
+    static {
+        REGISTRY.register(new DefaultRulesetRegister());
+        REGISTRY.register(new DefaultV2RulesetRegistry());
+    }
 
     private final Map<String, RulesetRegister> RULESETS;
 
@@ -22,12 +29,28 @@ public class RulesetRegistry {
         }
     }
 
+    public Optional<RulesetRegister> fromString(String rulesetIdentifier) {
+        if (!RULESETS.containsKey(rulesetIdentifier)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(RULESETS.get(rulesetIdentifier));
+    }
+
     public Optional<Game> createGame(String rulesetIdentifier) {
         if (!RULESETS.containsKey(rulesetIdentifier)) {
             return Optional.empty();
         }
 
         return Optional.of(new Game(RULESETS.get(rulesetIdentifier)));
+    }
+
+    public Optional<Ruleset> rulesetForRegisterIdentifier(String rulesetIdentifier) {
+        if (!RULESETS.containsKey(rulesetIdentifier)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new Ruleset(RULESETS.get(rulesetIdentifier)));
+        }
     }
 
     public List<String> getAllRulesetIdentifiers() {

--- a/src/main/java/pro/trevor/tankgame/rule/gameday/OpenHours.java
+++ b/src/main/java/pro/trevor/tankgame/rule/gameday/OpenHours.java
@@ -50,6 +50,10 @@ public class OpenHours implements IJsonObject {
             }
         }
 
+        if (openHours.isEmpty()) {
+            return true;
+        }
+
         for (DaySpec daySpec : openHours) {
             if (daySpec.isOpen(calendar)) {
                 return true;

--- a/src/main/java/pro/trevor/tankgame/rule/impl/action/Repair.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/action/Repair.java
@@ -17,10 +17,16 @@ public class Repair implements Action {
 
     private final int cost;
     private final int regeneration;
+    private final int maxRepairDurability;
 
     public Repair(int cost, int regeneration) {
+        this(cost, regeneration, Integer.MAX_VALUE);
+    }
+
+    public Repair(int cost, int regeneration, int maxRepairDurability) {
         this.cost = cost;
         this.regeneration = regeneration;
+        this.maxRepairDurability = maxRepairDurability;
     }
 
     @Override
@@ -62,8 +68,12 @@ public class Repair implements Action {
         }
 
         tank.put(Attribute.SCRAP, tank.getUnsafe(Attribute.SCRAP) - cost);
-        entity.put(Attribute.DURABILITY, entity.getUnsafe(Attribute.DURABILITY) + regeneration);
+        entity.put(Attribute.DURABILITY, Math.min(maxRepairDurability, entity.getUnsafe(Attribute.DURABILITY) + regeneration));
 
         return Error.NONE;
+    }
+
+    public int getMaxRepairDurability() {
+        return maxRepairDurability;
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/action/specialize/AttributeModifier.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/action/specialize/AttributeModifier.java
@@ -1,6 +1,55 @@
 package pro.trevor.tankgame.rule.impl.action.specialize;
 
+import org.json.JSONObject;
 import pro.trevor.tankgame.attribute.Attribute;
+import pro.trevor.tankgame.attribute.AttributeEntity;
+import pro.trevor.tankgame.util.IJsonObject;
+import pro.trevor.tankgame.util.JsonType;
 
-public record AttributeModifier(Attribute<Integer> attribute, Integer modifier) {
+import java.util.Objects;
+import java.util.Optional;
+
+@JsonType(name = "Modifier")
+public class AttributeModifier implements IJsonObject {
+    private final Attribute<Integer> attribute;
+    private final int modifier;
+
+    public AttributeModifier(Attribute<Integer> attribute, int modifier) {
+        this.attribute = attribute;
+        this.modifier = modifier;
+    }
+
+    public AttributeModifier(JSONObject json) {
+        Optional<Attribute<Integer>> maybeAttribute = Attribute.fromString(json.getString("attribute"), Integer.class);
+        this.attribute = maybeAttribute.get();
+        this.modifier = json.getInt("modifier");
+    }
+
+    public void apply(AttributeEntity entity) {
+        entity.put(attribute, entity.getOrElse(attribute, 0) + modifier);
+    }
+
+    public void remove(AttributeEntity entity) {
+        entity.put(attribute, entity.getOrElse(attribute, 0) - modifier);
+    }
+
+    @Override
+    public JSONObject toJson() {
+        JSONObject result = new JSONObject();
+        result.put("attribute", attribute.getName());
+        result.put("modifier", modifier);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof AttributeModifier that)) return false;
+        return modifier == that.modifier && Objects.equals(attribute, that.attribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attribute, modifier);
+    }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/action/specialize/Specialize.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/action/specialize/Specialize.java
@@ -8,14 +8,18 @@ import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.board.unit.Tank;
 import pro.trevor.tankgame.state.meta.PlayerRef;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class Specialize implements Action {
 
     private final int cost;
+    private final List<Specialty> availableSpecialties;
 
-    public Specialize(int cost) {
+    public Specialize(int cost, List<Specialty> availableSpecialties) {
         this.cost = cost;
+        this.availableSpecialties = new ArrayList<>(availableSpecialties);
     }
 
     @Override
@@ -41,6 +45,10 @@ public class Specialize implements Action {
 
         if (tank.getOrElse(Attribute.SCRAP, 0) < cost) {
             return new Error(Error.Type.OTHER, "Subject tank has insufficient scrap");
+        }
+
+        if (!availableSpecialties.contains(specialty)) {
+            return new Error(Error.Type.OTHER, "Target specialty does not exist");
         }
 
         if (tank.has(Attribute.SPECIALTY)) {

--- a/src/main/java/pro/trevor/tankgame/rule/impl/action/specialize/Specialty.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/action/specialize/Specialty.java
@@ -1,42 +1,75 @@
 package pro.trevor.tankgame.rule.impl.action.specialize;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
-import pro.trevor.tankgame.attribute.Attribute;
 import pro.trevor.tankgame.attribute.AttributeEntity;
 import pro.trevor.tankgame.util.IJsonObject;
 import pro.trevor.tankgame.util.JsonType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @JsonType(name = "Specialty")
-public enum Specialty implements IJsonObject {
-    Offense(new AttributeModifier(Attribute.DAMAGE_MODIFIER, 1), new AttributeModifier(Attribute.DEFENSE_MODIFIER, -1)),
-    Defense(new AttributeModifier(Attribute.DAMAGE_MODIFIER, -1), new AttributeModifier(Attribute.DEFENSE_MODIFIER, 2)),
-    Scout(new AttributeModifier(Attribute.DEFENSE_MODIFIER, -1), new AttributeModifier(Attribute.SPEED, 1), new AttributeModifier(Attribute.RANGE, 1)),
-    Melee(new AttributeModifier(Attribute.DAMAGE_MODIFIER, 1), new AttributeModifier(Attribute.DEFENSE_MODIFIER, -1), new AttributeModifier(Attribute.SPEED, 1), new AttributeModifier(Attribute.RANGE, -1))
-    ;
+public class Specialty implements IJsonObject {
 
-    final List<AttributeModifier> modifiers;
+    private final String name;
+    private final List<AttributeModifier> modifiers;
 
-    Specialty(AttributeModifier... modifiers) {
+
+    public Specialty(String name, AttributeModifier... modifiers) {
+        this.name = name;
         this.modifiers = Arrays.asList(modifiers);
+    }
+
+    public Specialty(JSONObject jsonObject) {
+        this.name = jsonObject.getString("name");
+
+        ArrayList<AttributeModifier> modifiers = new ArrayList<>();
+        JSONArray modifiersArray = jsonObject.getJSONArray("modifiers");
+        for (int i = 0; i < modifiersArray.length(); ++i) {
+            AttributeModifier modifier = new AttributeModifier(modifiersArray.getJSONObject(i));
+            modifiers.add(modifier);
+        }
+        this.modifiers = modifiers;
     }
 
     void apply(AttributeEntity entity) {
         for (AttributeModifier modifier : modifiers) {
-            entity.put(modifier.attribute(), entity.getOrElse(modifier.attribute(), 0) + modifier.modifier());
+            modifier.apply(entity);
         }
     }
 
     void remove(AttributeEntity entity) {
         for (AttributeModifier modifier : modifiers) {
-            entity.put(modifier.attribute(), entity.getOrElse(modifier.attribute(), 0) - modifier.modifier());
+            modifier.remove(entity);
         }
     }
 
     @Override
     public JSONObject toJson() {
-        return new JSONObject();
+        JSONObject result = new JSONObject();
+
+        JSONArray modifiersArray = new JSONArray();
+        for (AttributeModifier modifier : modifiers) {
+            modifiersArray.put(modifier.toJson());
+        }
+        result.put("modifiers", modifiersArray);
+        result.put("name", name);
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof Specialty specialty)) return false;
+        return Objects.equals(name, specialty.name) && Objects.equals(modifiers, specialty.modifiers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, modifiers);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/action/upgrade/Boon.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/action/upgrade/Boon.java
@@ -2,37 +2,43 @@ package pro.trevor.tankgame.rule.impl.action.upgrade;
 
 import org.json.JSONObject;
 import pro.trevor.tankgame.attribute.Attribute;
-import pro.trevor.tankgame.attribute.AttributeEntity;
-import pro.trevor.tankgame.attribute.Codec;
-import pro.trevor.tankgame.util.IJsonObject;
+import pro.trevor.tankgame.rule.impl.action.specialize.AttributeModifier;
 import pro.trevor.tankgame.util.JsonType;
 
+import java.util.Objects;
+
 @JsonType(name = "Boon")
-public enum Boon implements IJsonObject {
-    Attack(Attribute.DAMAGE_MODIFIER, 1),
-    Defense(Attribute.DEFENSE_MODIFIER, 1),
-    Speed(Attribute.SPEED, 1),
-    Range(Attribute.RANGE, 1)
-    ;
+public class Boon extends AttributeModifier {
 
-    private final Attribute<Integer> attribute;
-    private final int modifier;
+    private final String name;
 
-    Boon(Attribute<Integer> attribute, int modifier) {
-        this.attribute = attribute;
-        this.modifier = modifier;
+    public Boon(String name, Attribute<Integer> attribute, int modifier) {
+        super(attribute, modifier);
+        this.name = name;
     }
 
-    public void apply(AttributeEntity entity) {
-        entity.put(attribute, entity.getOrElse(attribute, 0) + modifier);
-    }
-
-    public void remove(AttributeEntity entity) {
-        entity.put(attribute, entity.getOrElse(attribute, 0) - modifier);
+    public Boon(JSONObject json) {
+        super(json);
+        name = json.getString("name");
     }
 
     @Override
     public JSONObject toJson() {
-        return new JSONObject();
+        JSONObject json = super.toJson();
+        json.put("name", name);
+        return json;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof Boon boon)) return false;
+        if (!super.equals(object)) return false;
+        return Objects.equals(name, boon.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/action/upgrade/Upgrade.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/action/upgrade/Upgrade.java
@@ -8,9 +8,18 @@ import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.board.unit.Tank;
 import pro.trevor.tankgame.state.meta.PlayerRef;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class Upgrade implements Action {
+
+    private final List<Boon> availableBoons;
+
+    public Upgrade(List<Boon> availableBoons) {
+        this.availableBoons = new ArrayList<>(availableBoons);
+    }
+
     @Override
     public Error apply(State state, LogEntry entry) {
         Optional<PlayerRef> maybeSubject = entry.get(Attribute.SUBJECT);
@@ -34,6 +43,10 @@ public class Upgrade implements Action {
 
         if (tank.has(Attribute.BOON)) {
             return new Error(Error.Type.OTHER, "Subject tank already has an upgrade");
+        }
+
+        if (!availableBoons.contains(boon)) {
+            return new Error(Error.Type.OTHER, "Target boon does not exist");
         }
 
         tank.put(Attribute.SCRAP, tank.getUnsafe(Attribute.SCRAP) - 6);

--- a/src/main/java/pro/trevor/tankgame/rule/impl/handle/DamageDurabilityHandle.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/handle/DamageDurabilityHandle.java
@@ -13,12 +13,15 @@ import pro.trevor.tankgame.util.Random;
 public class DamageDurabilityHandle implements DamageHandle {
 
     private final int[] distribution;
+    private final int minimumDamage;
 
-    public DamageDurabilityHandle() {
-        this.distribution = new int[]{1};
+    public DamageDurabilityHandle(int minimumDamage) {
+        this(minimumDamage, new int[]{1});
     }
 
-    public DamageDurabilityHandle(int[] distribution) {
+    public DamageDurabilityHandle(int minimumDamage, int[] distribution) {
+        assert minimumDamage >= 0;
+        this.minimumDamage = minimumDamage;
         this.distribution = distribution;
     }
 
@@ -41,8 +44,8 @@ public class DamageDurabilityHandle implements DamageHandle {
         int totalDamage = damage + attackModifier - defenseModifier;
 
         // If we might apply negative damage, set the damage to zero
-        if (totalDamage < 0) {
-            totalDamage = 0;
+        if (totalDamage < minimumDamage) {
+            totalDamage = minimumDamage;
         }
 
         entry.put(Attribute.DICE_ROLL, damage);

--- a/src/main/java/pro/trevor/tankgame/rule/impl/handle/DestroyTankHandle.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/handle/DestroyTankHandle.java
@@ -2,11 +2,13 @@ package pro.trevor.tankgame.rule.impl.handle;
 
 import pro.trevor.tankgame.attribute.Attribute;
 import pro.trevor.tankgame.attribute.AttributeEntity;
+import pro.trevor.tankgame.attribute.Entity;
 import pro.trevor.tankgame.rule.action.LogEntry;
 import pro.trevor.tankgame.rule.handle.DestroyHandle;
 import pro.trevor.tankgame.rule.handle.cause.Cause;
 import pro.trevor.tankgame.rule.handle.cause.TankCause;
 import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.state.board.unit.PseudoTank;
 import pro.trevor.tankgame.state.board.unit.Tank;
 import pro.trevor.tankgame.state.board.unit.Wall;
 import pro.trevor.tankgame.state.meta.Player;
@@ -17,27 +19,27 @@ public class DestroyTankHandle implements DestroyHandle {
     private final int wallDurability;
 
     public DestroyTankHandle(int wallDurability) {
+        assert wallDurability > 0;
         this.wallDurability = wallDurability;
     }
 
     @Override
     public void destroy(State state, Cause cause, AttributeEntity target, LogEntry entry) {
-        if (!(target instanceof Tank tank)) {
+        if (!(target instanceof Tank || target instanceof PseudoTank)) {
             return;
         }
 
         if (cause instanceof TankCause tankCause && !tankCause.getCause().equals(target)) {
             Tank causeTank = tankCause.getCause();
-            Player player = causeTank.getPlayerRef().toPlayer(state).get();
 
-            int previousScrap = player.getOrElse(Attribute.SCRAP, 0);
-            int tankScrap = tank.getOrElse(Attribute.SCRAP, 0);
-            int tankHasSponsorScrap = tank.has(Attribute.SPONSOR) ? 2 : 0;
+            int previousScrap = causeTank.getOrElse(Attribute.SCRAP, 0);
+            int tankScrap = target.getOrElse(Attribute.SCRAP, 0);
+            int tankHasSponsorScrap = target.has(Attribute.SPONSOR) ? 2 : 0;
 
-            player.put(Attribute.SCRAP,  previousScrap + tankScrap + tankHasSponsorScrap);
+            causeTank.put(Attribute.SCRAP,  previousScrap + tankScrap + tankHasSponsorScrap);
         }
 
-        Position targetPosition = tank.getPosition();
+        Position targetPosition = target.getUnsafe(Attribute.POSITION);
         state.getBoard().putUnit(new Wall(targetPosition, wallDurability));
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/handle/RewardScrapHandle.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/handle/RewardScrapHandle.java
@@ -1,0 +1,38 @@
+package pro.trevor.tankgame.rule.impl.handle;
+
+import pro.trevor.tankgame.attribute.Attribute;
+import pro.trevor.tankgame.attribute.AttributeEntity;
+import pro.trevor.tankgame.rule.action.LogEntry;
+import pro.trevor.tankgame.rule.handle.DestroyHandle;
+import pro.trevor.tankgame.rule.handle.cause.Cause;
+import pro.trevor.tankgame.rule.handle.cause.TankCause;
+import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.state.board.unit.Tank;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RewardScrapHandle implements DestroyHandle {
+
+    private final Map<Class<?>, Integer> rewardScrap;
+
+    public RewardScrapHandle(Map<Class<?>, Integer> rewardScrap) {
+        this.rewardScrap = new HashMap<>(rewardScrap);
+    }
+
+    private int rewardForExactClass(Class<?> type) {
+        return rewardScrap.getOrDefault(type, 0);
+    }
+
+    @Override
+    public void destroy(State state, Cause cause, AttributeEntity target, LogEntry entry) {
+        if (cause instanceof TankCause tankCause && !tankCause.getCause().equals(target)) {
+            Tank causeTank = tankCause.getCause();
+
+            int previousScrap = causeTank.getOrElse(Attribute.SCRAP, 0);
+            int reward = rewardForExactClass(target.getClass());
+
+            causeTank.put(Attribute.SCRAP,  previousScrap + reward);
+        }
+    }
+}

--- a/src/main/java/pro/trevor/tankgame/rule/impl/parameter/BoonSupplier.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/parameter/BoonSupplier.java
@@ -8,11 +8,21 @@ import pro.trevor.tankgame.rule.impl.action.upgrade.Boon;
 import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.meta.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class BoonSupplier implements AvailableParameterSupplier<Boon> {
+
+    private final List<Boon> values;
+
+    public BoonSupplier(List<Boon> values) {
+        this.values = new ArrayList<>(values);
+    }
+
+
     @Override
     public ParameterBound<Boon> possibleParameters(State state, Player player) {
-        return new DiscreteValueBound<>(Attribute.TARGET_BOON, Arrays.asList(Boon.values()));
+        return new DiscreteValueBound<>(Attribute.TARGET_BOON, values);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/parameter/SpecialtySupplier.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/parameter/SpecialtySupplier.java
@@ -8,11 +8,20 @@ import pro.trevor.tankgame.rule.impl.action.specialize.Specialty;
 import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.meta.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class SpecialtySupplier implements AvailableParameterSupplier<Specialty> {
+
+    private final List<Specialty> specialties;
+
+    public SpecialtySupplier(List<Specialty> specialties) {
+        this.specialties = new ArrayList<>(specialties);
+    }
+
     @Override
     public ParameterBound<Specialty> possibleParameters(State state, Player player) {
-        return new DiscreteValueBound<>(Attribute.TARGET_SPECIALTY, Arrays.asList(Specialty.values()));
+        return new DiscreteValueBound<>(Attribute.TARGET_SPECIALTY, specialties);
     }
 }

--- a/src/main/java/pro/trevor/tankgame/rule/impl/predicate/PlayerTankHasDurabilityBelowPrecondition.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/predicate/PlayerTankHasDurabilityBelowPrecondition.java
@@ -1,0 +1,37 @@
+package pro.trevor.tankgame.rule.impl.predicate;
+
+import pro.trevor.tankgame.attribute.Attribute;
+import pro.trevor.tankgame.rule.action.Error;
+import pro.trevor.tankgame.rule.action.Precondition;
+import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.state.board.unit.Tank;
+import pro.trevor.tankgame.state.meta.Player;
+
+import java.util.Optional;
+
+public class PlayerTankHasDurabilityBelowPrecondition implements Precondition {
+
+    private final int threshold;
+
+    public PlayerTankHasDurabilityBelowPrecondition(int threshold) {
+        assert threshold > 0;
+        this.threshold = threshold;
+    }
+
+
+    @Override
+    public Error test(State state, Player player) {
+        Optional<Tank> maybeTank = state.getTankForPlayerRef(player.toRef());
+        if (maybeTank.isEmpty()) {
+            return new Error(Error.Type.PRECONDITION, "Player has no tank");
+        }
+
+        Tank tank = maybeTank.get();
+
+        if (tank.getOrElse(Attribute.DURABILITY, 0) >= threshold) {
+            return new Error(Error.Type.OTHER, "Tank cannot be repaired above " + threshold + " durability");
+        }
+
+        return Error.NONE;
+    }
+}

--- a/src/main/java/pro/trevor/tankgame/rule/impl/ruleset/DefaultV2RulesetRegistry.java
+++ b/src/main/java/pro/trevor/tankgame/rule/impl/ruleset/DefaultV2RulesetRegistry.java
@@ -1,0 +1,110 @@
+package pro.trevor.tankgame.rule.impl.ruleset;
+
+import pro.trevor.tankgame.attribute.Attribute;
+import pro.trevor.tankgame.rule.Ruleset;
+import pro.trevor.tankgame.rule.RulesetRegister;
+import pro.trevor.tankgame.rule.action.ActionRule;
+import pro.trevor.tankgame.rule.action.ActionRuleset;
+import pro.trevor.tankgame.rule.action.Description;
+import pro.trevor.tankgame.rule.action.Predicate;
+import pro.trevor.tankgame.rule.action.parameter.Parameter;
+import pro.trevor.tankgame.rule.apply.ApplyRule;
+import pro.trevor.tankgame.rule.apply.ApplyRuleset;
+import pro.trevor.tankgame.rule.apply.TargetApplyRule;
+import pro.trevor.tankgame.rule.handle.Damage;
+import pro.trevor.tankgame.rule.handle.Destroy;
+import pro.trevor.tankgame.rule.impl.action.Move;
+import pro.trevor.tankgame.rule.impl.action.Repair;
+import pro.trevor.tankgame.rule.impl.action.Shoot;
+import pro.trevor.tankgame.rule.impl.action.specialize.AttributeModifier;
+import pro.trevor.tankgame.rule.impl.action.specialize.Specialize;
+import pro.trevor.tankgame.rule.impl.action.specialize.Specialty;
+import pro.trevor.tankgame.rule.impl.action.upgrade.Boon;
+import pro.trevor.tankgame.rule.impl.action.upgrade.Upgrade;
+import pro.trevor.tankgame.rule.impl.apply.LastTeamStandingCheck;
+import pro.trevor.tankgame.rule.impl.apply.ModifyAttribute;
+import pro.trevor.tankgame.rule.impl.handle.*;
+import pro.trevor.tankgame.rule.impl.parameter.*;
+import pro.trevor.tankgame.rule.impl.predicate.*;
+import pro.trevor.tankgame.state.board.unit.Tank;
+import pro.trevor.tankgame.state.board.unit.Wall;
+import pro.trevor.tankgame.util.LineOfSight;
+
+import java.util.List;
+import java.util.Map;
+
+public class DefaultV2RulesetRegistry implements RulesetRegister {
+    @Override
+    public String getIdentifier() {
+        return "RulesetV2";
+    }
+
+    @Override
+    public void registerPlayerRules(Ruleset ruleset) {
+        // Player with tank rules
+        ActionRuleset actionRuleset = ruleset.getPlayerActionRuleset();
+        actionRuleset.add(
+                new Description("Move", "Move your tank to a new position on the game board"),
+                new ActionRule(new Predicate(List.of(new PlayerTankIsPresentPrecondition(), new PlayerTankCanActPreondition(), new PlayerTankHasAttributePrecondition(Attribute.SPEED)), List.of()),
+                        new Move(), new Parameter<>("Position", Attribute.TARGET_POSITION, new MovePositionSupplier())));
+        actionRuleset.add(
+                new Description("Shoot", "Shoot at a position to damage its occupant"),
+                new ActionRule(new Predicate(List.of(new PlayerTankIsPresentPrecondition(), new PlayerTankCanActPreondition(), new PlayerTankHasAttributePrecondition(Attribute.RANGE)), List.of()),
+                        new Shoot(ruleset), new Parameter<>("Target", Attribute.TARGET_POSITION, new ShootPositionSupplier(LineOfSight::hasLineOfSight))));
+        actionRuleset.add(
+                new Description("Repair", "Spend two scrap to repair a target tank, wall, or bridge within range for two durability"),
+                new ActionRule(new Predicate(List.of(new PlayerTankIsPresentPrecondition(), new PlayerTankHasScrapPrecondition(2), new PlayerTankCanActPreondition(), new PlayerTankHasDurabilityBelowPrecondition(12)), List.of()),
+                        new Repair(2, 2, 12), new Parameter<>("Target", Attribute.TARGET_POSITION, new RepairPositionSupplier())));
+
+        Specialty offenseSpec = new Specialty("Offense", new AttributeModifier(Attribute.DAMAGE_MODIFIER, 2), new AttributeModifier(Attribute.DEFENSE_MODIFIER, -2));
+        Specialty scoutSpec = new Specialty("Scout", new AttributeModifier(Attribute.DEFENSE_MODIFIER, -2), new AttributeModifier(Attribute.SPEED, 1), new AttributeModifier(Attribute.RANGE, 1));
+        Specialty meleeSpec = new Specialty("Melee", new AttributeModifier(Attribute.DAMAGE_MODIFIER, 3), new AttributeModifier(Attribute.DEFENSE_MODIFIER, -1), new AttributeModifier(Attribute.SPEED, 1), new AttributeModifier(Attribute.RANGE, -1));
+        List<Specialty> specialties = List.of(offenseSpec, scoutSpec, meleeSpec);
+        actionRuleset.add(
+                new Description("Specialize", "Spend four scrap to hone your tank to a specialized style of combat"),
+                new ActionRule(new Predicate(List.of(new PlayerTankIsPresentPrecondition(), new PlayerTankHasScrapPrecondition(4), new PlayerTankCanActPreondition()), List.of()),
+                        new Specialize(4, specialties), new Parameter<>("Specialty", Attribute.TARGET_SPECIALTY, new SpecialtySupplier(specialties))
+                )
+        );
+
+        Boon attackBoon = new Boon("Attack", Attribute.DAMAGE_MODIFIER, 2);
+        Boon defenseBoon = new Boon("Defence", Attribute.DEFENSE_MODIFIER, 2);
+        Boon rangeBoon = new Boon("Range", Attribute.RANGE, 1);
+        Boon speedBoon = new Boon("Speed", Attribute.SPEED, 1);
+        List<Boon> boons = List.of(attackBoon, defenseBoon, rangeBoon, speedBoon);
+        actionRuleset.add(
+                new Description("Upgrade", "Once per game, spend six scrap to upgrade an attribute of your tank"),
+                new ActionRule(new Predicate(List.of(new PlayerTankIsPresentPrecondition(), new PlayerTankHasNoBoonPrecondition(), new PlayerTankHasScrapPrecondition(6), new PlayerTankCanActPreondition()), List.of()),
+                        new Upgrade(boons), new Parameter<>("Boon", Attribute.TARGET_BOON, new BoonSupplier(boons))
+                )
+        );
+    }
+
+    @Override
+    public void registerTickRules(Ruleset ruleset) {
+        ApplyRuleset tickRuleset = ruleset.getTickRuleset();
+        tickRuleset.add(new TargetApplyRule<>(new ModifyAttribute<>(Attribute.CAN_ACT, ((state, target) -> true)), Tank.class));
+    }
+
+    @Override
+    public void registerConditionalRules(Ruleset ruleset) {
+        ApplyRuleset conditionalRuleset = ruleset.getConditionalRuleset();
+        conditionalRuleset.add(new ApplyRule(new LastTeamStandingCheck()));
+    }
+
+    @Override
+    public void registerDamageHandlers(List<Damage> damageHandlers) {
+        damageHandlers.add(new Damage(new HasDurabilityPredicate().and(new IsTankPredicate()), new DamageDurabilityHandle(1, new int[]{1, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 6})));
+        damageHandlers.add(new Damage(new HasDurabilityPredicate(), new DamageDurabilityHandle(1)));
+    }
+
+    @Override
+    public void registerDestroyHandlers(List<Destroy> destroysHandlers) {
+        destroysHandlers.add(new Destroy(new HasZeroDurabilityPredicate(), new DestroyEntityHandle()));
+        destroysHandlers.add(new Destroy(new HasZeroDurabilityPredicate(), new RewardScrapHandle(Map.of(
+                Tank.class, 4,
+                Wall.class, 1
+        ))));
+        destroysHandlers.add(new Destroy(new HasZeroDurabilityPredicate().and(new IsTankPredicate()), new DestroyTankHandle(2)));
+    }
+}

--- a/src/main/java/pro/trevor/tankgame/state/builder/Builder.java
+++ b/src/main/java/pro/trevor/tankgame/state/builder/Builder.java
@@ -1,9 +1,9 @@
-package pro.trevor.tankgame.state;
+package pro.trevor.tankgame.state.builder;
 
 import org.json.JSONObject;
 import pro.trevor.tankgame.attribute.Attribute;
-import pro.trevor.tankgame.attribute.AttributeEntity;
 import pro.trevor.tankgame.attribute.ListEntity;
+import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.state.board.*;
 import pro.trevor.tankgame.state.board.unit.Tank;
 import pro.trevor.tankgame.state.meta.Council;
@@ -11,10 +11,7 @@ import pro.trevor.tankgame.state.meta.Player;
 import pro.trevor.tankgame.util.Position;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 
 public class Builder {
@@ -27,6 +24,7 @@ public class Builder {
         this.templates = new HashMap<>();
         this.board = new Board(width, height);
 
+        players = new ArrayList<>(players);
         this.players = new ListEntity<>();
         Collections.shuffle(players);
         for (String player : players) {

--- a/src/main/java/pro/trevor/tankgame/state/builder/SurroundedByWalls.java
+++ b/src/main/java/pro/trevor/tankgame/state/builder/SurroundedByWalls.java
@@ -1,0 +1,93 @@
+package pro.trevor.tankgame.state.builder;
+
+import pro.trevor.tankgame.Game;
+import pro.trevor.tankgame.attribute.Attribute;
+import pro.trevor.tankgame.rule.gameday.OpenHours;
+import pro.trevor.tankgame.rule.impl.ruleset.DefaultV2RulesetRegistry;
+import pro.trevor.tankgame.state.State;
+import pro.trevor.tankgame.state.board.Element;
+import pro.trevor.tankgame.state.board.unit.Tank;
+import pro.trevor.tankgame.state.board.unit.Wall;
+import pro.trevor.tankgame.state.meta.PlayerRef;
+import pro.trevor.tankgame.util.Position;
+import pro.trevor.tankgame.web.server.Environment;
+import pro.trevor.tankgame.web.server.GameInfo;
+import pro.trevor.tankgame.web.server.Storage;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class SurroundedByWalls {
+
+    public static void makeGame(int width, int height, List<String> names) {
+        assert width >= 8;
+        assert height >= 8;
+        assert names.size() == 16;
+
+        Builder builder = new Builder(width, height, names);
+
+        builder.template("wall1", new Wall(new Position(0, 0), 1));
+        builder.template("wall2", new Wall(new Position(0, 0), 2));
+
+        int halfWidth = (width - 1) / 2;
+        int halfHeight = (height - 1) / 2;
+
+        for (int i = 0; i < width; ++i) {
+            builder.placeElement(builder.instance("wall1"), new Position(i, halfHeight));
+            if (height % 2 == 0) {
+                builder.placeElement(builder.instance("wall1"), new Position(i, halfHeight + 1));
+            }
+        }
+        for (int i = 0; i < height; ++i) {
+            builder.placeElement(builder.instance("wall1"), new Position(halfWidth, i));
+            if (height % 2 == 0) {
+                builder.placeElement(builder.instance("wall1"), new Position(halfWidth + 1, i));
+            }
+        }
+
+        for (int i = 0; i < width; ++i) {
+            builder.placeElement(builder.instance("wall2"), new Position(i, 0));
+            builder.placeElement(builder.instance("wall2"), new Position(i, height - 1));
+        }
+        for (int i = 0; i < height; ++i) {
+            builder.placeElement(builder.instance("wall2"), new Position(0, i));
+            builder.placeElement(builder.instance("wall2"), new Position(width - 1, i));
+        }
+
+        Tank tankTemplate = new Tank(new PlayerRef("None"), new Position(0, 0), Map.of());
+        tankTemplate.put(Attribute.SCRAP, 4);
+        tankTemplate.put(Attribute.DURABILITY, 12);
+        tankTemplate.put(Attribute.DAMAGE_MODIFIER, 0);
+        tankTemplate.put(Attribute.DEFENSE_MODIFIER, 0);
+        tankTemplate.put(Attribute.SPEED, 2);
+        tankTemplate.put(Attribute.RANGE, 2);
+        tankTemplate.put(Attribute.CAN_ACT, true);
+        builder.template("tank", tankTemplate);
+
+        String[] teams = new String[]{"Red", "Yellow", "Blue", "Green"};
+        Position[] basePositions = new Position[]{new Position(0, 0), new Position(0, 6), new Position(6, 0), new Position(6, 6)};
+        Position[] offsets = new Position[]{new Position(2, 2), new Position(2, 3), new Position(3, 2), new Position(3, 3)};
+        for (int i = 0; i < basePositions.length; ++i) {
+            Position basePosition = basePositions[i];
+            String team = teams[i];
+
+            for (Position offsetPosition : offsets) {
+                Element tank = builder.instance("tank");
+                tank.put(Attribute.TEAM, team);
+                builder.placeElement(tank, new Position(basePosition.x() + offsetPosition.x(), basePosition.y() + offsetPosition.y()));
+            }
+        }
+
+        builder.modifyPlayers((player) -> {
+        });
+        State state = builder.build();
+
+        Game game = new Game(new DefaultV2RulesetRegistry(), state);
+        GameInfo gameInfo = new GameInfo("Tank Game Redux^2", UUID.randomUUID(), new OpenHours(), game.getRulesetRegister());
+        Storage storage = new Storage(new File(Environment.getStoragePath()));
+        storage.saveGameInitialState(gameInfo, game);
+    }
+
+}

--- a/src/main/java/pro/trevor/tankgame/web/server/GameInfo.java
+++ b/src/main/java/pro/trevor/tankgame/web/server/GameInfo.java
@@ -1,29 +1,43 @@
 package pro.trevor.tankgame.web.server;
 
 import org.json.JSONObject;
-import pro.trevor.tankgame.Game;
+import pro.trevor.tankgame.rule.Ruleset;
+import pro.trevor.tankgame.rule.RulesetRegister;
 import pro.trevor.tankgame.rule.RulesetRegistry;
 import pro.trevor.tankgame.rule.gameday.OpenHours;
-import pro.trevor.tankgame.state.State;
 import pro.trevor.tankgame.util.IJsonObject;
 
+import java.util.Objects;
 import java.util.UUID;
 
-public record GameInfo(String name, UUID uuid, OpenHours openHours, Game game) implements IJsonObject {
+public final class GameInfo implements IJsonObject {
 
     public static final String NAME = "name";
     public static final String UUID = "uuid";
-    public static final String STATE = "state";
     public static final String RULESET = "ruleset";
     public static final String OPEN_HOURS = "open_hours";
 
+    private final String name;
+    private final UUID uuid;
+    private final OpenHours openHours;
+    private final RulesetRegister rulesetRegister;
+
+    private final Ruleset ruleset;
+
+    public GameInfo(String name, UUID uuid, OpenHours openHours, RulesetRegister rulesetRegister) {
+        this.name = name;
+        this.uuid = uuid;
+        this.openHours = openHours;
+        this.rulesetRegister = rulesetRegister;
+        this.ruleset = new Ruleset(rulesetRegister);
+    }
+
     public GameInfo(JSONObject json) {
-        this(json.getString(NAME),
-                java.util.UUID.fromString(json.getString(UUID)),
-                new OpenHours(json.optJSONObject(OPEN_HOURS, new OpenHours().toJson())),
-                RulesetRegistry.REGISTRY.createGame(json.getString(RULESET)).orElseThrow()
-        );
-        this.game.setState(new State(json.getJSONObject(STATE)));
+        this.name = json.getString(NAME);
+        this.uuid = java.util.UUID.fromString(json.getString(UUID));
+        this.openHours = new OpenHours(json.optJSONObject(OPEN_HOURS, new OpenHours().toJson()));
+        this.rulesetRegister = RulesetRegistry.REGISTRY.fromString(json.getString(RULESET)).orElseThrow();
+        this.ruleset = new Ruleset(rulesetRegister);
     }
 
     @Override
@@ -31,18 +45,54 @@ public record GameInfo(String name, UUID uuid, OpenHours openHours, Game game) i
         JSONObject result = new JSONObject();
         result.put(NAME, name);
         result.put(UUID, uuid.toString());
-        result.put(RULESET, game.getRulesetIdentifier());
+        result.put(RULESET, rulesetRegister.getIdentifier());
         result.put(OPEN_HOURS, openHours.toJson());
-        result.put(STATE, game.getState().toJson());
         return result;
     }
 
-    public JSONObject toJsonWithoutState() {
-        JSONObject result = new JSONObject();
-        result.put(NAME, name);
-        result.put(UUID, uuid.toString());
-        result.put(OPEN_HOURS, openHours.toJson());
-        result.put(RULESET, game.getRulesetIdentifier());
-        return result;
+    public String name() {
+        return name;
     }
+
+    public UUID uuid() {
+        return uuid;
+    }
+
+    public OpenHours openHours() {
+        return openHours;
+    }
+
+    public RulesetRegister rulesetRegister() {
+        return rulesetRegister;
+    }
+
+    public Ruleset ruleset() {
+        return ruleset;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (GameInfo) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.uuid, that.uuid) &&
+                Objects.equals(this.openHours, that.openHours) &&
+                Objects.equals(this.rulesetRegister.getIdentifier(), that.rulesetRegister.getIdentifier());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, uuid, openHours, rulesetRegister.getIdentifier());
+    }
+
+    @Override
+    public String toString() {
+        return "GameInfo[" +
+                "name=" + name + ", " +
+                "uuid=" + uuid + ", " +
+                "openHours=" + openHours + ", " +
+                "rulesetIdentifier=" + rulesetRegister.getIdentifier() + ']';
+    }
+
 }

--- a/src/main/java/pro/trevor/tankgame/web/server/ServerMain.java
+++ b/src/main/java/pro/trevor/tankgame/web/server/ServerMain.java
@@ -2,14 +2,11 @@ package pro.trevor.tankgame.web.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import pro.trevor.tankgame.rule.RulesetRegistry;
-import pro.trevor.tankgame.rule.impl.ruleset.DefaultRulesetRegister;
 
 @SpringBootApplication
 public class ServerMain {
 
     public static void main(String[] args) {
-        RulesetRegistry.REGISTRY.register(new DefaultRulesetRegister());
         SpringApplication.run(ServerMain.class, args);
     }
 


### PR DESCRIPTION
* Version bump to 0.1.0
* Games created before 0.1.0 will not ingest properly on and after 0.1.0

Engine updates
* Added ruleset DefaultV2: no scrap heaps; instead walls and tanks reward scrap on destruction
* Stricter rules applications
  * Validates preconditions before committing action
* Updated boons and upgrades to be ruleset-defined
* Added a maximum value to the repair action
* Updated game storage to be less redundant; now each game will store one less state
* Added a new map builder for a 10x10 map surrounded by walls with four teams and 16 players
* Bug fix: an empty open-hours structure no longer restricts actions to never being allowed
* Bug fix: destruction of a tank now gives the tank causing the destruction the proper scrap reward
* Bug fix: pseudo-tank actions now have checks in place

Client Updates
* Added custom and consistent ordering to attributes displayed on screen
* Bug fix: logbook will no longer jump to last game every two seconds
* Bug fix: attributes will now be displayed even if the value is zero
* Bug fix: added space between action title and error if it exists